### PR TITLE
Fire onConnect event when connection established

### DIFF
--- a/src/com/codebutler/android_websockets/SocketIOClient.java
+++ b/src/com/codebutler/android_websockets/SocketIOClient.java
@@ -169,6 +169,7 @@ public class SocketIOClient {
                         mClient.send("2:::");
                     }
                 }, mHeartbeat);
+                mHandler.onConnect();
             }
         }, null);
         mClient.connect();


### PR DESCRIPTION
Thanks for getting socket.io communications working with native android. This is really awesome.

Anyway, in the SocketIOClient, `onConnect()` never called `mHandler.onConnect()`, so the onConnect method in the SocketIOClient.Handler was never being called.
