### PR TITLE
Use ANDROID_HOME environment variable to locate SDK

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -28,6 +28,15 @@
          -->
     <property file="ant.properties" />
 
+    <!-- if sdk.dir was not set from one of the property file, then
+         get it from the ANDROID_HOME env var.
+         This must be done before we load project.properties since
+         the proguard config can use sdk.dir -->
+    <property environment="env" />
+    <condition property="sdk.dir" value="${env.ANDROID_HOME}">
+        <isset property="env.ANDROID_HOME" />
+    </condition>
+
     <!-- The project.properties file is created and updated by the 'android'
          tool, as well as ADT.
 
@@ -41,7 +50,7 @@
 
     <!-- quick check on sdk.dir -->
     <fail
-            message="sdk.dir is missing. Make sure to generate local.properties using 'android update project' or to inject it through an env var"
+            message="sdk.dir is missing. Make sure to generate local.properties using 'android update project' or to inject it through the ANDROID_HOME environment variable."
             unless="sdk.dir"
     />
 


### PR DESCRIPTION
Just updated build.xml via command `android update project --path android-websockets` to get an option to locate SDK with env variable. Was introduced in one of the recent versions of SDK tools.
This could be helpful for using Jenkins to build project depending on the android-websockets library.
