### PR TITLE
Fixed double firing of onConnect().

### DIFF
--- a/src/com/codebutler/android_websockets/SocketIOClient.java
+++ b/src/com/codebutler/android_websockets/SocketIOClient.java
@@ -129,7 +129,8 @@ public class SocketIOClient {
                     int code = Integer.parseInt(parts[0]);
                     switch (code) {
                     case 1:
-                        onConnect();
+                        // connect
+                        mHandler.onConnect();
                         break;
                     case 2:
                         // heartbeat
@@ -239,7 +240,6 @@ public class SocketIOClient {
                         mClient.send("2:::");
                     }
                 }, mHeartbeat);
-                mHandler.onConnect();
             }
         }, null);
         mClient.connect();


### PR DESCRIPTION
Fixed issue where the onConnect() event in a SocketIOClient handler is fired twice for a single connection: once from the run() method in WebSocketClient, and once from the onMessage() event in SocketIOClient. It would seem that the later is redundant.
