### PR TITLE
Update SocketIOClient.java - onError failed on nullPointerException

### DIFF
--- a/src/com/codebutler/android_websockets/SocketIOClient.java
+++ b/src/com/codebutler/android_websockets/SocketIOClient.java
@@ -250,7 +250,8 @@ public class SocketIOClient {
     }
 
     private void cleanup() {
-        mClient.disconnect();
+        if (mClient != null)
+            mClient.disconnect();
         mClient = null;
        
         mSendLooper.quit();


### PR DESCRIPTION
onError sometimes is fired, after disconnect was called. 
Then cleanup code is failing on null exception.
