### PR TITLE
README fix for endpoint callback

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ gen
 .project
 local.properties
 /.settings
+project.properties

--- a/README.md
+++ b/README.md
@@ -45,10 +45,6 @@ WebSocketClient client = new WebSocketClient(URI.create("wss://irccloud.com"), n
         Log.e(TAG, "Error!", error);
     }
 
-    @Override
-    public void onConnectToEndpoint(String endpoint) {
-        Log.d(TAG, "Connected to endpoint")
-    }
 }, extraHeaders);
 
 client.connect();

--- a/README.md
+++ b/README.md
@@ -44,6 +44,11 @@ WebSocketClient client = new WebSocketClient(URI.create("wss://irccloud.com"), n
     public void onError(Exception error) {
         Log.e(TAG, "Error!", error);
     }
+
+    @Override
+    public void onConnectToEndpoint(String endpoint) {
+        Log.d(TAG, "Connected to endpoint")
+    }
 }, extraHeaders);
 
 client.connect();
@@ -89,6 +94,11 @@ SocketIOClient client = new SocketIOClient(URI.create("wss://example.com"), new 
     @Override
     public void onError(Exception error) {
         Log.e(TAG, "Error!", error);
+    }
+
+    @Override
+    public void onConnectToEndpoint(String endpoint) {
+        Log.d(TAG, "Connected to endpoint")
     }
 });
 


### PR DESCRIPTION
the new endpoint connected callback is mandatory in the handler
interface, without it the README example doesn't work
