### PR TITLE
Avoid mSocket NPE if WebSocketClient.disconnect() is called twice

### DIFF
--- a/src/com/codebutler/android_websockets/WebSocketClient.java
+++ b/src/com/codebutler/android_websockets/WebSocketClient.java
@@ -150,14 +150,16 @@ public class WebSocketClient {
             mHandler.post(new Runnable() {
                 @Override
                 public void run() {
-                    try {
-                        mSocket.close();
+                    if (mSocket != null) {
+                        try {
+                            mSocket.close();
+                        } catch (IOException ex) {
+                            Log.d(TAG, "Error while disconnecting", ex);
+                            mListener.onError(ex);
+                        }
                         mSocket = null;
-                        mConnected = false;
-                    } catch (IOException ex) {
-                        Log.d(TAG, "Error while disconnecting", ex);
-                        mListener.onError(ex);
                     }
+                    mConnected = false;
                 }
             });
         }


### PR DESCRIPTION
If WebSocketClient.disconnect() is called twice quickly, two runnables might be posted to because mSocket might not be null yet if the first runnable has not be run yet.

This change double-checks whether mSocket still needs to be closed when the runnable eventually runs. It also ensures mSocket = null and mConnected = false if mSocket.close() throws an IOException.
