### PR TITLE
Avoid calling cleanup twice on error condition

### DIFF
--- a/src/com/codebutler/android_websockets/SocketIOClient.java
+++ b/src/com/codebutler/android_websockets/SocketIOClient.java
@@ -291,7 +291,6 @@ public class SocketIOClient {
                         throw new Exception("unknown code");
                     }
                 } catch (Exception ex) {
-                    cleanup();
                     onError(ex);
                 }
             }


### PR DESCRIPTION
It's already being called in the `onError` method.
