### PR TITLE
Better handle queries when building the session url

### DIFF
--- a/src/com/koushikdutta/async/http/socketio/SocketIOConnection.java
+++ b/src/com/koushikdutta/async/http/socketio/SocketIOConnection.java
@@ -10,6 +10,7 @@ import java.util.Hashtable;
 import org.json.JSONArray;
 import org.json.JSONObject;
 
+import android.net.Uri;
 import android.os.Handler;
 import android.text.TextUtils;
 
@@ -114,8 +115,9 @@ class SocketIOConnection {
                     if (!set.contains("websocket"))
                         throw new Exception("websocket not supported");
 
-                    final String sessionUrl = request.getUri().toString()
-                            + "websocket/" + session + "/";
+                    final String sessionUrl = Uri.parse(request.getUri()).buildUpon()
+                    		.appendPath("websocket").appendPath(session)
+                    		.build().toString();
                     
                     SocketIOConnection.this.webSocketClient =  new WebSocketClient(URI.create(sessionUrl), new Listener() {
                         


### PR DESCRIPTION
Hey Koush. I found an issue using query parameters in the SocketIOClient connection url.

My socket url is of the form

```
http://localhost:80?foo=bar
```

SocketIORequest correctly appends "/socket.io/1/" to the url using Uri.Builder making it

```
http://localhost:80/socket.io/1/?foo=bar
```

Once a successful SocketIOConnection is made, the session url is constructed by appending the session to the request url directly. This buggers up query parameters breaking the url.

```
http://localhost:80/socket.io/1/?foo=bar/ztRH4c0RG7GQ8nIzoa5J/
```

My changes instead use Uri.Builder, similar to what is done in the SocketIORequest, to construct the session url.

```
http://localhost:80/socket.io/1/websocket/N1MtCSEO6PqyJKqeoa5K?foo=bar
```
