### PR TITLE
The query string must be appended to the path in its original url encoded form

### DIFF
--- a/src/com/codebutler/android_websockets/WebSocketClient.java
+++ b/src/com/codebutler/android_websockets/WebSocketClient.java
@@ -75,8 +75,8 @@ public class WebSocketClient {
                     int port = (mURI.getPort() != -1) ? mURI.getPort() : ((mURI.getScheme().equals("wss") || mURI.getScheme().equals("https")) ? 443 : 80);
 
                     String path = TextUtils.isEmpty(mURI.getPath()) ? "/" : mURI.getPath();
-                    if (!TextUtils.isEmpty(mURI.getQuery())) {
-                        path += "?" + mURI.getQuery();
+                    if (!TextUtils.isEmpty(mURI.getRawQuery())) {
+                        path += "?" + mURI.getRawQuery();
                     }
 
                     String originScheme = mURI.getScheme().equals("wss") ? "https" : "http";


### PR DESCRIPTION
The query string must be appended to the path in its original url encoded form. It was required to make the library work with SignalR which uses query string to establish connection.
